### PR TITLE
The new version of libmseed's ms3_readmsr method only has four parameters

### DIFF
--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@ main (int argc, char **argv)
     flags |= MSF_UNPACKDATA;
 
   /* Loop over the input file record by record */
-  while ((retcode = ms3_readmsr (&msr, inputfile, NULL, NULL,
+  while ((retcode = ms3_readmsr (&msr, inputfile, 
                                  flags, verbose)) == MS_NOERROR)
   {
     totalrecs++;
@@ -98,7 +98,7 @@ main (int argc, char **argv)
   }
 
   /* Make sure everything is cleaned up */
-  ms3_readmsr (&msr, NULL, NULL, NULL, 0, 0);
+  ms3_readmsr (&msr, NULL, 0, 0);
 
   if (basicsum)
   {


### PR DESCRIPTION
The new version of libmseed's ms3_readmsr()  method only has four parameters, see https://earthscope.github.io/libmseed/group__io-functions.html#gabb15ee422d81c42ed32bdeda94dfd87f

fixbug with "too many arguments ":

```
main.c:44:34: error: too many arguments to function call, expected 4, have 6
                                 flags, verbose)) == MS_NOERROR)
                                 ^~~~~~~~~~~~~~
/usr/local/include/libmseed.h:738:1: note: 'ms3_readmsr' declared here
extern int ms3_readmsr (MS3Record **ppmsr, const char *mspath, uint32_t fl...
^
main.c:101:40: error: too many arguments to function call, expected 4, have 6
  ms3_readmsr (&msr, NULL, NULL, NULL, 0, 0);
  ~~~~~~~~~~~                          ^~~~
```